### PR TITLE
fix(azure): constrain content safety secret exposure

### DIFF
--- a/src/elspeth/plugins/transforms/azure/base.py
+++ b/src/elspeth/plugins/transforms/azure/base.py
@@ -16,6 +16,7 @@ import time
 from collections.abc import Callable, Mapping
 from threading import Event, Lock
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 import structlog
@@ -43,9 +44,31 @@ logger = structlog.get_logger(__name__)
 _CAPACITY_RETRY_INITIAL_DELAY_SECONDS = 0.05
 _CAPACITY_RETRY_MAX_DELAY_SECONDS = 1.0
 _AZURE_HTTP_TIMEOUT_SECONDS = 30.0
+_AZURE_CONTENT_SAFETY_ENDPOINT_SUFFIXES = (
+    ".cognitiveservices.azure.com",
+    ".api.cognitive.microsoft.com",
+)
 
 
 _warn_telemetry_before_start = make_warn_telemetry_before_start(logger)
+
+
+def _validate_azure_content_safety_endpoint(v: str) -> str:
+    """Return a credential-safe Azure Content Safety endpoint URL.
+
+    Azure safety transforms send the configured API key as an
+    ``Ocp-Apim-Subscription-Key`` header.  Constrain user-provided endpoints to
+    Azure AI Services hosts so a server-scoped Content Safety key cannot be
+    exfiltrated to arbitrary HTTPS infrastructure.
+    """
+    stripped = validate_credential_safe_https_url(v, field_name="endpoint")
+    hostname = urlparse(stripped).hostname
+    if hostname is None:
+        raise ValueError("endpoint must include a hostname")
+    normalized = hostname.casefold().rstrip(".")
+    if not any(normalized.endswith(suffix) for suffix in _AZURE_CONTENT_SAFETY_ENDPOINT_SUFFIXES):
+        raise ValueError("endpoint must be an Azure Content Safety endpoint")
+    return stripped
 
 
 class BaseAzureSafetyConfig(TransformDataConfig):
@@ -66,7 +89,7 @@ class BaseAzureSafetyConfig(TransformDataConfig):
     @field_validator("endpoint")
     @classmethod
     def _validate_endpoint_url(cls, v: str) -> str:
-        return validate_credential_safe_https_url(v, field_name="endpoint")
+        return _validate_azure_content_safety_endpoint(v)
 
     @field_validator("api_key")
     @classmethod

--- a/src/elspeth/web/config.py
+++ b/src/elspeth/web/config.py
@@ -199,7 +199,6 @@ class WebSettings(BaseModel):
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",
         "AZURE_API_KEY",
-        "AZURE_CONTENT_SAFETY_KEY",
     )
     orphan_run_max_age_seconds: int = Field(default=3600, ge=60)
     orphan_run_check_interval_seconds: int = Field(default=300, ge=30)

--- a/tests/unit/plugins/transforms/azure/test_content_safety.py
+++ b/tests/unit/plugins/transforms/azure/test_content_safety.py
@@ -2006,13 +2006,21 @@ class TestEndpointURLValidation:
         from elspeth.plugins.transforms.azure.content_safety import AzureContentSafetyConfig
 
         with pytest.raises(PluginConfigError, match=r"(?i)credentials"):
-            AzureContentSafetyConfig.from_dict(self._make_config_dict("https://user:pass@test.azure.com"))
+            AzureContentSafetyConfig.from_dict(self._make_config_dict("https://user:pass@test.cognitiveservices.azure.com"))
+
+    def test_non_azure_https_endpoint_rejected(self) -> None:
+        from elspeth.plugins.transforms.azure.content_safety import AzureContentSafetyConfig
+
+        with pytest.raises(PluginConfigError, match=r"(?i)azure content safety"):
+            AzureContentSafetyConfig.from_dict(self._make_config_dict("https://attacker.example"))
 
     def test_endpoint_with_path_accepted(self) -> None:
         from elspeth.plugins.transforms.azure.content_safety import AzureContentSafetyConfig
 
-        cfg = AzureContentSafetyConfig.from_dict(self._make_config_dict("https://test.azure.com/safety/v1"))
-        assert cfg.endpoint == "https://test.azure.com/safety/v1"
+        cfg = AzureContentSafetyConfig.from_dict(
+            self._make_config_dict("https://test.cognitiveservices.azure.com/safety/v1")
+        )
+        assert cfg.endpoint == "https://test.cognitiveservices.azure.com/safety/v1"
 
 
 class TestDuplicateCategoryDetection:

--- a/tests/unit/web/test_config.py
+++ b/tests/unit/web/test_config.py
@@ -629,6 +629,17 @@ class TestPathFieldValidation:
 class TestServerSecretAllowlistValidation:
     """Tests for server_secret_allowlist field validation."""
 
+    def test_azure_content_safety_key_not_allowlisted_by_default(self) -> None:
+        settings = WebSettings(
+            composer_max_composition_turns=15,
+            composer_max_discovery_turns=10,
+            composer_timeout_seconds=85.0,
+            composer_rate_limit_per_minute=10,
+            shareable_link_signing_key=b"\x00" * 32,
+        )
+
+        assert "AZURE_CONTENT_SAFETY_KEY" not in settings.server_secret_allowlist
+
     def test_reserved_elspeth_server_secret_names_rejected(self) -> None:
         with pytest.raises(ValidationError, match="ELSPETH_"):
             WebSettings(


### PR DESCRIPTION
### Motivation
- Prevent accidental exfiltration of a server-scoped Azure Content Safety key when a user-configured Azure safety transform points at an attacker-controlled HTTPS endpoint. 
- Remove default advertising of a server secret that lowers the authorization boundary and instead require operator opt-in for server-scoped Content Safety keys. 
- Constrain credential-bearing endpoints so the transform only sends operator secrets to trusted Azure Content Safety hosts.

### Description
- Remove `AZURE_CONTENT_SAFETY_KEY` from the default `server_secret_allowlist` in `src/elspeth/web/config.py` so it is not resolvable by default. 
- Add `_validate_azure_content_safety_endpoint` to `src/elspeth/plugins/transforms/azure/base.py` which applies `validate_credential_safe_https_url` then enforces host suffixes (`.cognitiveservices.azure.com` and `.api.cognitive.microsoft.com`) to limit credential-bearing endpoints to Azure AI hosts. 
- Wire the new validator into `BaseAzureSafetyConfig._validate_endpoint_url` so Azure safety transforms reject arbitrary HTTPS hosts. 
- Add/adjust unit regression coverage in `tests/unit/plugins/transforms/azure/test_content_safety.py` and `tests/unit/web/test_config.py` to assert rejection of non-Azure endpoints and that `AZURE_CONTENT_SAFETY_KEY` is not allowlisted by default.

### Testing
- Attempted to run the targeted unit tests with `pytest` (`tests/unit/plugins/transforms/azure/test_content_safety.py::TestEndpointURLValidation` and `tests/unit/web/test_config.py::TestServerSecretAllowlistValidation`) but test execution was blocked due to a missing test dependency (`hypothesis`) in the environment. 
- Attempted `uv sync --extra dev` to install dev deps but it was blocked by a network/tunnel error while downloading `pandas-stubs`. 
- Successfully performed static/quick checks with `python -m py_compile` on the modified modules which completed without syntax errors. 
- Ran `git diff --check` (local change validation) which produced no whitespace/merge errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb1b2b08083239baaaf5a585ace35)