### PR TITLE
fix(web): remove run ids from progress metrics

### DIFF
--- a/src/elspeth/web/execution/progress.py
+++ b/src/elspeth/web/execution/progress.py
@@ -284,7 +284,7 @@ class ProgressBroadcaster:
                 queue.get_nowait()
                 drained += 1
             if drained > 0:
-                ProgressBroadcaster._record_queue_pressure(telemetry=telemetry, run_id=run_id, reason="terminal_drain", count=drained)
+                ProgressBroadcaster._record_queue_pressure(telemetry=telemetry, reason="terminal_drain", count=drained)
             queue.put_nowait(event)  # Queue is now empty — this cannot fail
             return
 
@@ -295,14 +295,13 @@ class ProgressBroadcaster:
         # backpressure policy for a slow client — record it as a best-effort
         # drop so the loss is observable rather than silent.
         queue.get_nowait()
-        ProgressBroadcaster._record_queue_pressure(telemetry=telemetry, run_id=run_id, reason="queue_full", count=1)
+        ProgressBroadcaster._record_queue_pressure(telemetry=telemetry, reason="queue_full", count=1)
         queue.put_nowait(event)
 
     @staticmethod
     def _record_queue_pressure(
         *,
         telemetry: _SessionsTelemetry | None,
-        run_id: str,
         reason: str,
         count: int,
     ) -> None:
@@ -310,7 +309,7 @@ class ProgressBroadcaster:
             return
         telemetry.progress_broadcast_dropped_total.add(
             count,
-            attributes={"reason": reason, "run_id": run_id},
+            attributes={"reason": reason},
         )
 
     def cleanup_run(self, run_id: str) -> None:

--- a/src/elspeth/web/sessions/telemetry.py
+++ b/src/elspeth/web/sessions/telemetry.py
@@ -298,7 +298,7 @@ def build_sessions_telemetry(*, meter: _Meter | None = None) -> _SessionsTelemet
         progress_broadcast_dropped_total=meter.create_counter(
             "execution.progress.broadcast_dropped_total",
             description=(
-                "Execution progress WebSocket broadcasts dropped or drained under client backpressure. Attributes: reason, run_id when available."
+                "Execution progress WebSocket broadcasts dropped or drained under client backpressure. Attributes: reason."
             ),
         ),
         orphaned_runs_cancelled_total=meter.create_counter(

--- a/tests/unit/web/execution/test_progress.py
+++ b/tests/unit/web/execution/test_progress.py
@@ -602,7 +602,7 @@ class TestProgressBroadcasterCallbackBacklogBound:
         assert isinstance(counter, _FakeCounter)
         amount, attrs, _context = counter.calls[0]
         assert amount == queue.maxsize
-        assert attrs == {"reason": "terminal_drain", "run_id": "run-1"}
+        assert attrs == {"reason": "terminal_drain"}
 
     def test_queue_full_drop_emits_telemetry_instead_of_logging(self) -> None:
         mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
@@ -619,7 +619,7 @@ class TestProgressBroadcasterCallbackBacklogBound:
         assert isinstance(counter, _FakeCounter)
         amount, attrs, _context = counter.calls[0]
         assert amount == 1
-        assert attrs == {"reason": "queue_full", "run_id": "run-1"}
+        assert attrs == {"reason": "queue_full"}
 
 
 class TestProgressBroadcasterCleanup:


### PR DESCRIPTION
### Motivation
- Prevent high-cardinality and disclosure risk in Prometheus metrics by removing per-run `run_id` labels from the WebSocket progress backpressure counter.
- Keep operational observability (drop counts and reasons) while ensuring Prometheus time-series cardinality remains bounded.

### Description
- Stop passing `run_id` into the backpressure telemetry path in `src/elspeth/web/execution/progress.py` so emitted counter attributes only include the low-cardinality `reason` label.
- Update the metric description in `src/elspeth/web/sessions/telemetry.py` to document only the `reason` attribute.
- Adjust unit test expectations in `tests/unit/web/execution/test_progress.py` to assert the counter calls contain only `{"reason": ...}` attributes instead of `{"reason": ..., "run_id": ...}`.

### Testing
- Ran linting: `ruff check src/elspeth/web/execution/progress.py src/elspeth/web/sessions/telemetry.py tests/unit/web/execution/test_progress.py` which passed.
- Checked byte-compile of modified files: `python -m compileall -q src/elspeth/web/execution/progress.py src/elspeth/web/sessions/telemetry.py tests/unit/web/execution/test_progress.py` which succeeded.
- Attempted unit test run: `pytest tests/unit/web/execution/test_progress.py` which could not run due to a missing test dependency (`ModuleNotFoundError: No module named 'hypothesis'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36087d0df88323aa34e4e548970e57)