### PR TITLE
fix(security): remove committed staging credentials

### DIFF
--- a/docs/composer/evidence/composer-passivity-rgr-investigation-2026-05-06.md
+++ b/docs/composer/evidence/composer-passivity-rgr-investigation-2026-05-06.md
@@ -50,7 +50,7 @@ The user explicitly authorised building one ("you can create a new harness if yo
 
 `evals/composer-rgr/run_scenario.sh`:
 
-1. `POST /api/auth/login` with `dta_user` / `dta_pass`, capture JWT
+1. `POST /api/auth/login` with credentials loaded from the approved secret manager, capture JWT
 2. `POST /api/sessions` to create a fresh session
 3. `POST /api/sessions/{sid}/messages` with the scenario's `opening_prompt` (the exact failing user prompt from the captured session)
 4. `GET /api/sessions/{sid}/messages` to capture the full thread

--- a/docs/composer/evidence/composer-skill-gaps-2026-05-09.md
+++ b/docs/composer/evidence/composer-skill-gaps-2026-05-09.md
@@ -163,7 +163,7 @@ The example `deep_routing` covers a real-world pattern — multi-rule routing fo
 # 1. Auth + create session
 TOKEN=$(curl -sS -X POST https://elspeth.foundryside.dev/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"username":"dta_user","password":"dta_pass"}' \
+  -d '{"username":"REDACTED_LOAD_FROM_SECRET_MANAGER","password":"REDACTED_LOAD_FROM_SECRET_MANAGER"}' \
   | python3 -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
 
 SID=$(curl -sS -X POST https://elspeth.foundryside.dev/api/sessions \

--- a/docs/composer/evidence/composer-tier1.5-final-cohort-report-2026-05-07.md
+++ b/docs/composer/evidence/composer-tier1.5-final-cohort-report-2026-05-07.md
@@ -213,7 +213,7 @@ I initially hypothesised that the parallel-cohort REDs were a concurrency artefa
 ```bash
 # Re-fire the three demo-shape sequential cohorts (6 runs each):
 export ELSPETH_EVAL_BASE_URL=https://elspeth.foundryside.dev
-export ELSPETH_EVAL_USER=dta_user ELSPETH_EVAL_PASS=dta_pass
+export ELSPETH_EVAL_USER=REDACTED_LOAD_FROM_SECRET_MANAGER ELSPETH_EVAL_PASS=REDACTED_LOAD_FROM_SECRET_MANAGER
 cd /home/john/elspeth/.worktrees/composer-tier1.5-hardening/evals/composer-rgr
 
 # url-download (re-baseline)

--- a/docs/superpowers/plans/2026-06-06-tutorial-reliability-harness.md
+++ b/docs/superpowers/plans/2026-06-06-tutorial-reliability-harness.md
@@ -38,10 +38,12 @@ Invocation environment (from `playwright.staging.config.ts` header):
 ```bash
 cd src/elspeth/web/frontend
 export STAGING_BASE_URL=https://elspeth.foundryside.dev
-export STAGING_USERNAME=dta_user
-export STAGING_PASSWORD=dta_pass
+export STAGING_USERNAME="${STAGING_USERNAME:?set from secret manager}"
+export STAGING_PASSWORD="${STAGING_PASSWORD:?set from secret manager}"
 export PLAYWRIGHT_BACKEND_BASE_URL=https://elspeth.foundryside.dev
 ```
+
+Do not commit concrete staging credentials in this plan or follow-up docs; load the account name and password from the approved secret manager immediately before running the commands. Rotate any staging credential that has previously appeared in repository history.
 
 The auth token is written to `tests/e2e/.auth/staging-user.json` by `tests/e2e/setup/staging-global-setup.ts` (already exists). Helpers read it with `tokenFromStorageState` from `helpers/api.ts`.
 
@@ -387,7 +389,7 @@ test.describe("tutorial reliability skeleton", () => {
 Run:
 ```bash
 cd src/elspeth/web/frontend
-STAGING_BASE_URL=https://elspeth.foundryside.dev STAGING_USERNAME=dta_user STAGING_PASSWORD=dta_pass \
+STAGING_BASE_URL=https://elspeth.foundryside.dev STAGING_USERNAME="${STAGING_USERNAME:?set from secret manager}" STAGING_PASSWORD="${STAGING_PASSWORD:?set from secret manager}" \
 PLAYWRIGHT_BACKEND_BASE_URL=https://elspeth.foundryside.dev \
 npx playwright test --config=playwright.staging.config.ts tutorial-reliability.staging.spec.ts
 ```
@@ -605,7 +607,7 @@ Run:
 ```bash
 cd src/elspeth/web/frontend
 HARNESS_BATCH_ID=verify-2 HARNESS_BATCH_SIZE=2 \
-STAGING_BASE_URL=https://elspeth.foundryside.dev STAGING_USERNAME=dta_user STAGING_PASSWORD=dta_pass \
+STAGING_BASE_URL=https://elspeth.foundryside.dev STAGING_USERNAME="${STAGING_USERNAME:?set from secret manager}" STAGING_PASSWORD="${STAGING_PASSWORD:?set from secret manager}" \
 PLAYWRIGHT_BACKEND_BASE_URL=https://elspeth.foundryside.dev \
 npx playwright test --config=playwright.staging.config.ts tutorial-reliability.staging.spec.ts
 ls tests/e2e/.harness-results/verify-2/
@@ -718,7 +720,7 @@ Run:
 ```bash
 cd src/elspeth/web/frontend
 HARNESS_BATCH_ID=batch-2026-06-06 HARNESS_BATCH_SIZE=10 \
-STAGING_BASE_URL=https://elspeth.foundryside.dev STAGING_USERNAME=dta_user STAGING_PASSWORD=dta_pass \
+STAGING_BASE_URL=https://elspeth.foundryside.dev STAGING_USERNAME="${STAGING_USERNAME:?set from secret manager}" STAGING_PASSWORD="${STAGING_PASSWORD:?set from secret manager}" \
 PLAYWRIGHT_BACKEND_BASE_URL=https://elspeth.foundryside.dev \
 npx playwright test --config=playwright.staging.config.ts tutorial-reliability.staging.spec.ts
 ```

--- a/evals/2026-05-03-composer/hardmode/harness.sh
+++ b/evals/2026-05-03-composer/hardmode/harness.sh
@@ -24,6 +24,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SID_FILE=""
 JWT_FILE=""
+: "${ELSPETH_EVAL_BASE_URL:=https://elspeth.foundryside.dev}"
+: "${ELSPETH_EVAL_USER:?set ELSPETH_EVAL_USER from the approved secret manager}"
+: "${ELSPETH_EVAL_PASS:?set ELSPETH_EVAL_PASS from the approved secret manager}"
 
 scenario_id="${1:-}"
 if [[ -z "$scenario_id" ]]; then echo "usage: $0 <scenario_id>"; exit 1; fi
@@ -37,16 +40,16 @@ mkdir -p $out
 cp "$scen" $out/scenario.json
 
 # --- step 1: login fresh ---
-curl -fsS -X POST https://elspeth.foundryside.dev/api/auth/login \
+curl -fsS -X POST "$ELSPETH_EVAL_BASE_URL/api/auth/login" \
   -H 'Content-Type: application/json' \
-  -d '{"username":"dta_user","password":"dta_pass"}' \
+  -d "$(jq -n --arg username "$ELSPETH_EVAL_USER" --arg password "$ELSPETH_EVAL_PASS" '{username:$username,password:$password}')" \
   | jq -r '.access_token' > $out/jwt.txt
 J=$(cat $out/jwt.txt)
 [[ -n "$J" ]] || { echo "login failed"; exit 2; }
 
 # --- step 2: create session ---
 title=$(jq -r '.task_summary' $out/scenario.json)
-curl -fsS -X POST https://elspeth.foundryside.dev/api/sessions \
+curl -fsS -X POST "$ELSPETH_EVAL_BASE_URL/api/sessions" \
   -H "Authorization: Bearer $J" -H 'Content-Type: application/json' \
   -d "$(jq -n --arg t "hardmode/$scenario_id $title" '{title:$t}')" \
   -o $out/session.json
@@ -61,7 +64,7 @@ if [[ -n "$csv_filename" ]]; then
     --rawfile body <(jq -r '.csv_content' $out/scenario.json) \
     '{filename:$fn, mime_type:"text/csv", content:$body}' \
     > $out/blob.req.json
-  curl -fsS -X POST "https://elspeth.foundryside.dev/api/sessions/$sid/blobs/inline" \
+  curl -fsS -X POST "$ELSPETH_EVAL_BASE_URL/api/sessions/$sid/blobs/inline" \
     -H "Authorization: Bearer $J" -H 'Content-Type: application/json' \
     --data @$out/blob.req.json -o $out/blob.json
 fi

--- a/evals/composer-rgr/README.md
+++ b/evals/composer-rgr/README.md
@@ -66,8 +66,8 @@ LLM↔tool turns the API path filters out.
 cd evals/composer-rgr
 cat > .env <<EOF
 ELSPETH_EVAL_BASE_URL=https://elspeth.foundryside.dev
-ELSPETH_EVAL_USER=dta_user
-ELSPETH_EVAL_PASS=dta_pass
+ELSPETH_EVAL_USER=REDACTED_LOAD_FROM_SECRET_MANAGER
+ELSPETH_EVAL_PASS=REDACTED_LOAD_FROM_SECRET_MANAGER
 EOF
 chmod 600 .env
 

--- a/evals/composer-rgr/run_scenario.sh
+++ b/evals/composer-rgr/run_scenario.sh
@@ -8,8 +8,8 @@
 #
 # Usage:
 #   ELSPETH_EVAL_BASE_URL=https://elspeth.foundryside.dev \
-#   ELSPETH_EVAL_USER=dta_user \
-#   ELSPETH_EVAL_PASS=dta_pass \
+#   ELSPETH_EVAL_USER=REDACTED_LOAD_FROM_SECRET_MANAGER \
+#   ELSPETH_EVAL_PASS=REDACTED_LOAD_FROM_SECRET_MANAGER \
 #   ./run_scenario.sh [run_label]
 #
 # Selecting a scenario:

--- a/src/elspeth/web/frontend/playwright.staging.config.ts
+++ b/src/elspeth/web/frontend/playwright.staging.config.ts
@@ -14,7 +14,7 @@
 //
 // Invocation:
 //   STAGING_BASE_URL=https://elspeth.foundryside.dev \
-//   STAGING_USERNAME=dta_user STAGING_PASSWORD=dta_pass \
+//   STAGING_USERNAME="${STAGING_USERNAME:?set from secret manager}" STAGING_PASSWORD="${STAGING_PASSWORD:?set from secret manager}" \
 //   PLAYWRIGHT_BACKEND_BASE_URL=https://elspeth.foundryside.dev \
 //   npx playwright test --config=playwright.staging.config.ts composer-preferences
 
@@ -43,7 +43,7 @@ export default defineConfig({
   testIgnore: ["**/setup/**", "**/page-objects/**", "**/helpers/**", "**/*.test.ts"],
   // Sequential, single-worker for staging — we are talking to a shared
   // service and don't want parallel test runs colliding on the same
-  // dta_user account's preferences row.
+  // configured staging account's preferences row.
   fullyParallel: false,
   workers: 1,
   retries: 0,

--- a/src/elspeth/web/frontend/tests/e2e/harness/README.md
+++ b/src/elspeth/web/frontend/tests/e2e/harness/README.md
@@ -24,14 +24,14 @@ re-run, diagnostics) live in `../helpers/tutorial-harness.ts`.
 
 The staging config (`playwright.staging.config.ts`) is single-worker,
 `fullyParallel:false`, `retries:0`, so runs are **sequential** (one shared
-`dta_user` account) and **all** runs execute even if some fail. Invoke from the
+configured staging account) and **all** runs execute even if some fail. Invoke from the
 frontend dir:
 
 ```bash
 cd src/elspeth/web/frontend
 HARNESS_BATCH_ID=batch-2026-06-06 HARNESS_BATCH_SIZE=10 \
 STAGING_BASE_URL=https://elspeth.foundryside.dev \
-STAGING_USERNAME=dta_user STAGING_PASSWORD=dta_pass \
+STAGING_USERNAME="${STAGING_USERNAME:?set from secret manager}" STAGING_PASSWORD="${STAGING_PASSWORD:?set from secret manager}" \
 PLAYWRIGHT_BACKEND_BASE_URL=https://elspeth.foundryside.dev \
 npx playwright test --config=playwright.staging.config.ts tutorial-reliability.staging.spec.ts
 ```
@@ -40,6 +40,11 @@ npx playwright test --config=playwright.staging.config.ts tutorial-reliability.s
 |---------|---------|---------|
 | `HARNESS_BATCH_ID` | `skeleton` | Names the batch; results land under `tests/e2e/.harness-results/<batch_id>/` (gitignored) and the report lands at `notes/tutorial-reliability/<batch_id>.md`. |
 | `HARNESS_BATCH_SIZE` | `1` | How many independent tutorial runs the battery enumerates. |
+
+Load `STAGING_USERNAME` and `STAGING_PASSWORD` from the approved secret
+manager before running the command; never commit concrete staging credentials.
+Rotate any staging credential that has previously appeared in repository
+history.
 
 The four `STAGING_*` / `PLAYWRIGHT_BACKEND_BASE_URL` vars are required by
 `playwright.staging.config.ts` and the global-setup auth step.


### PR DESCRIPTION
### Motivation
- Remove committed concrete staging credentials (`STAGING_USERNAME=dta_user`, `STAGING_PASSWORD=dta_pass`) that expose a shared staging account and enable unwanted access to the live staging deployment. 
- Replace embedded secrets with explicit instructions to load credentials from the approved secret manager and require operators to rotate any previously committed credentials.

### Description
- Replaced hardcoded `STAGING_USERNAME`/`STAGING_PASSWORD` and other concrete credential examples with secret-driven environment-variable expansions like `"${STAGING_USERNAME:?set from secret manager}"` in `docs/superpowers/plans/2026-06-06-tutorial-reliability-harness.md`, `src/elspeth/web/frontend/tests/e2e/harness/README.md`, and `src/elspeth/web/frontend/playwright.staging.config.ts`.
- Parameterized eval/harness scripts to read credentials from environment variables and fail-fast if unset, including `evals/2026-05-03-composer/hardmode/harness.sh` and `evals/composer-rgr/run_scenario.sh`, and built the login payload programmatically (via `jq`) instead of embedding username/password literals.
- Redacted older runnable documentation and evidence examples that repeated the same staging credentials, replacing them with placeholders like `REDACTED_LOAD_FROM_SECRET_MANAGER` or guidance to load from the secret manager.
- Added explicit doc guidance not to commit concrete staging credentials and to rotate any credential already exposed in repository history; committed the changes on the branch and opened the PR.

### Testing
- Ran `bash -n evals/2026-05-03-composer/hardmode/harness.sh` and `bash -n evals/composer-rgr/run_scenario.sh` to validate shell syntax; both succeeded.
- Searched the repository with `rg` for occurrences of `dta_user`, `dta_pass`, and common STAGING/EVAL credential patterns to confirm remediation; the grep-based checks returned no remaining embedded `dta_user`/`dta_pass` usages in the modified locations.
- Ran `git diff --check` to ensure no whitespace/conflict markers; it passed.
- Created the commit and PR titled `fix(security): remove committed staging credentials` (changes committed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26aad9710c832393de32dad6b8a6f6)