### PR TITLE
fix(plugins): bound batch QA aggregation amplification

### DIFF
--- a/src/elspeth/plugins/transforms/_scalar_buckets.py
+++ b/src/elspeth/plugins/transforms/_scalar_buckets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Hashable, Iterable
 
 type ScalarBucketKey = tuple[type[object], object]
 
@@ -10,6 +10,13 @@ type ScalarBucketKey = tuple[type[object], object]
 def scalar_bucket_key(value: object) -> ScalarBucketKey:
     """Return a hashable key that keeps equal cross-type scalars separate."""
     return (type(value), value)
+
+
+def hashable_scalar_bucket_key(value: object) -> ScalarBucketKey | None:
+    """Return a type-aware bucket key when ``value`` can safely enter a set/dict."""
+    if not isinstance(value, Hashable):
+        return None
+    return scalar_bucket_key(value)
 
 
 def same_scalar_bucket_value(left: object, right: object) -> bool:
@@ -26,3 +33,40 @@ def append_unique_bucket_value[T](values: list[T], candidate: T) -> None:
     """Append ``candidate`` only if no type-aware bucket match already exists."""
     if not scalar_bucket_contains(values, candidate):
         values.append(candidate)
+
+
+def append_unique_bucket_value_with_seen[T](
+    values: list[T],
+    candidate: T,
+    *,
+    seen_hashable: set[ScalarBucketKey],
+    seen_unhashable: list[T],
+) -> None:
+    """Append ``candidate`` once using O(1) tracking for hashable bucket values."""
+    key = hashable_scalar_bucket_key(candidate)
+    if key is not None:
+        if key in seen_hashable:
+            return
+        seen_hashable.add(key)
+        values.append(candidate)
+        return
+
+    if scalar_bucket_contains(seen_unhashable, candidate):
+        return
+    seen_unhashable.append(candidate)
+    values.append(candidate)
+
+
+def unique_bucket_values[T](candidates: Iterable[T]) -> list[T]:
+    """Return first-seen unique values under type-aware scalar equality."""
+    values: list[T] = []
+    seen_hashable: set[ScalarBucketKey] = set()
+    seen_unhashable: list[T] = []
+    for candidate in candidates:
+        append_unique_bucket_value_with_seen(
+            values,
+            candidate,
+            seen_hashable=seen_hashable,
+            seen_unhashable=seen_unhashable,
+        )
+    return values

--- a/src/elspeth/plugins/transforms/batch_drift_compare.py
+++ b/src/elspeth/plugins/transforms/batch_drift_compare.py
@@ -20,9 +20,10 @@ from elspeth.plugins.infrastructure.config_base import TransformDataConfig
 from elspeth.plugins.infrastructure.results import TransformResult
 from elspeth.plugins.transforms._scalar_buckets import (
     ScalarBucketKey,
-    append_unique_bucket_value,
+    hashable_scalar_bucket_key,
     same_scalar_bucket_value,
     scalar_bucket_key,
+    unique_bucket_values,
 )
 
 type BatchDriftCompareRow = dict[str, object]
@@ -55,11 +56,16 @@ _NUMERIC_OUTPUT_FIELDS = _COMMON_OUTPUT_FIELDS | frozenset(
         "mean_delta",
     }
 )
+_MAX_CATEGORY_DETAIL_ITEMS = 1_000
+
 _CATEGORICAL_OUTPUT_FIELDS = _COMMON_OUTPUT_FIELDS | frozenset(
     {
+        "category_shift_count",
         "category_shifts",
+        "category_shifts_truncated",
         "chi_square_statistic",
         "new_categories",
+        "new_categories_truncated",
         "new_category_count",
         "total_variation",
     }
@@ -127,7 +133,7 @@ class BatchDriftCompare(BaseTransform):
     name = "batch_drift_compare"
     determinism = Determinism.DETERMINISTIC
     plugin_version = "1.0.0"
-    source_file_hash: str | None = "sha256:b96cdf96069ddb27"
+    source_file_hash: str | None = "sha256:7a60495bee8a8e68"
     config_model = BatchDriftCompareConfig
     is_batch_aware = True
 
@@ -207,14 +213,32 @@ class BatchDriftCompare(BaseTransform):
 
     def _collect_cohorts(self, rows: list[PipelineRow]) -> list[tuple[Any, list[PipelineRow]]]:
         cohorts: list[tuple[Any, list[PipelineRow]]] = []
+        cohort_indexes: dict[ScalarBucketKey, int] = {}
+        unhashable_cohort_indexes: list[tuple[Any, int]] = []
         for row in rows:
             cohort_value = row[self._cohort_field]
-            for existing_cohort, cohort_rows in cohorts:
-                if same_scalar_bucket_value(cohort_value, existing_cohort):
-                    cohort_rows.append(row)
-                    break
+            cohort_key = hashable_scalar_bucket_key(cohort_value)
+            if cohort_key is not None:
+                cohort_index = cohort_indexes.get(cohort_key)
             else:
-                cohorts.append((cohort_value, [row]))
+                cohort_index = next(
+                    (
+                        existing_index
+                        for existing_cohort, existing_index in unhashable_cohort_indexes
+                        if same_scalar_bucket_value(cohort_value, existing_cohort)
+                    ),
+                    None,
+                )
+
+            if cohort_index is None:
+                cohort_index = len(cohorts)
+                cohorts.append((cohort_value, []))
+                if cohort_key is not None:
+                    cohort_indexes[cohort_key] = cohort_index
+                else:
+                    unhashable_cohort_indexes.append((cohort_value, cohort_index))
+
+            cohorts[cohort_index][1].append(row)
         return cohorts
 
     def _numeric_values_for(self, cohort: Any, rows: list[PipelineRow]) -> _CohortValues:
@@ -298,26 +322,42 @@ class BatchDriftCompare(BaseTransform):
     def _ks_statistic(left: tuple[int | float, ...], right: tuple[int | float, ...]) -> float:
         left_values = sorted(float(value) for value in left)
         right_values = sorted(float(value) for value in right)
-        thresholds = sorted(set(left_values + right_values))
+        left_len = len(left_values)
+        right_len = len(right_values)
+        left_index = 0
+        right_index = 0
         max_distance = 0.0
-        for threshold in thresholds:
-            left_cdf = sum(1 for value in left_values if value <= threshold) / len(left_values)
-            right_cdf = sum(1 for value in right_values if value <= threshold) / len(right_values)
+
+        while left_index < left_len or right_index < right_len:
+            if right_index >= right_len or (left_index < left_len and left_values[left_index] <= right_values[right_index]):
+                threshold = left_values[left_index]
+            else:
+                threshold = right_values[right_index]
+
+            while left_index < left_len and left_values[left_index] <= threshold:
+                left_index += 1
+            while right_index < right_len and right_values[right_index] <= threshold:
+                right_index += 1
+
+            left_cdf = left_index / left_len
+            right_cdf = right_index / right_len
             max_distance = max(max_distance, abs(left_cdf - right_cdf))
+
         return max_distance
 
     @staticmethod
-    def _categorical_shifts(baseline: _CohortValues, cohort: _CohortValues) -> tuple[list[dict[str, object]], float, float, list[object]]:
+    def _categorical_shifts(
+        baseline: _CohortValues, cohort: _CohortValues
+    ) -> tuple[list[dict[str, object]], float, float, list[object], int, int, bool, bool]:
         baseline_counts: Counter[ScalarBucketKey] = Counter(scalar_bucket_key(value) for value in baseline.values)
         cohort_counts: Counter[ScalarBucketKey] = Counter(scalar_bucket_key(value) for value in cohort.values)
-        values: list[object] = []
-        for value in baseline.values + cohort.values:
-            append_unique_bucket_value(values, value)
+        values = unique_bucket_values(baseline.values + cohort.values)
 
         shifts: list[dict[str, object]] = []
         total_variation_sum = 0.0
         chi_square = 0.0
         new_categories: list[object] = []
+        total_new_category_count = 0
         for value in values:
             value_key = scalar_bucket_key(value)
             baseline_count = baseline_counts[value_key]
@@ -329,19 +369,31 @@ class BatchDriftCompare(BaseTransform):
             if expected > 0:
                 chi_square += ((cohort_count - expected) ** 2) / expected
             if baseline_count == 0 and cohort_count > 0:
-                new_categories.append(value)
-            shifts.append(
-                {
-                    "value": value,
-                    "baseline_count": baseline_count,
-                    "cohort_count": cohort_count,
-                    "baseline_proportion": baseline_prop,
-                    "cohort_proportion": cohort_prop,
-                    "proportion_delta": cohort_prop - baseline_prop,
-                }
-            )
+                total_new_category_count += 1
+                if len(new_categories) < _MAX_CATEGORY_DETAIL_ITEMS:
+                    new_categories.append(value)
+            if len(shifts) < _MAX_CATEGORY_DETAIL_ITEMS:
+                shifts.append(
+                    {
+                        "value": value,
+                        "baseline_count": baseline_count,
+                        "cohort_count": cohort_count,
+                        "baseline_proportion": baseline_prop,
+                        "cohort_proportion": cohort_prop,
+                        "proportion_delta": cohort_prop - baseline_prop,
+                    }
+                )
 
-        return shifts, 0.5 * total_variation_sum, chi_square, new_categories
+        return (
+            shifts,
+            0.5 * total_variation_sum,
+            chi_square,
+            new_categories,
+            total_new_category_count,
+            len(values),
+            len(values) > _MAX_CATEGORY_DETAIL_ITEMS,
+            total_new_category_count > len(new_categories),
+        )
 
     def _base_result(self, *, baseline: _CohortValues, cohort: _CohortValues, batch_size: int) -> BatchDriftCompareRow:
         return {
@@ -386,15 +438,27 @@ class BatchDriftCompare(BaseTransform):
         return result
 
     def _categorical_result(self, *, baseline: _CohortValues, cohort: _CohortValues, batch_size: int) -> BatchDriftCompareRow:
-        shifts, total_variation, chi_square, new_categories = self._categorical_shifts(baseline, cohort)
+        (
+            shifts,
+            total_variation,
+            chi_square,
+            new_categories,
+            total_new_category_count,
+            category_shift_count,
+            category_shifts_truncated,
+            new_categories_truncated,
+        ) = self._categorical_shifts(baseline, cohort)
         result = self._base_result(baseline=baseline, cohort=cohort, batch_size=batch_size)
         result.update(
             {
                 "category_shifts": shifts,
+                "category_shift_count": category_shift_count,
+                "category_shifts_truncated": category_shifts_truncated,
                 "total_variation": total_variation,
                 "chi_square_statistic": chi_square,
-                "new_category_count": len(new_categories),
+                "new_category_count": total_new_category_count,
                 "new_categories": new_categories,
+                "new_categories_truncated": new_categories_truncated,
             }
         )
         return result

--- a/src/elspeth/plugins/transforms/batch_outlier_annotator.py
+++ b/src/elspeth/plugins/transforms/batch_outlier_annotator.py
@@ -22,6 +22,8 @@ from elspeth.plugins.infrastructure.results import TransformResult
 
 type BatchOutlierAnnotationRow = dict[str, object]
 
+_MAX_INDEX_DETAIL_ITEMS = 1_000
+
 _ANNOTATION_FIELD_SUFFIXES = (
     "batch_size",
     "is_outlier",
@@ -30,8 +32,10 @@ _ANNOTATION_FIELD_SUFFIXES = (
     "median",
     "missing_count",
     "missing_indices",
+    "missing_indices_truncated",
     "non_finite_count",
     "non_finite_indices",
+    "non_finite_indices_truncated",
     "reason",
     "robust_z_score",
     "robust_z_threshold",
@@ -142,7 +146,7 @@ class BatchOutlierAnnotator(BaseTransform):
     name = "batch_outlier_annotator"
     determinism = Determinism.DETERMINISTIC
     plugin_version = "1.0.0"
-    source_file_hash: str | None = "sha256:0fb500fc231b82f9"
+    source_file_hash: str | None = "sha256:8d56aa8f81dd7fdc"
     config_model = BatchOutlierAnnotatorConfig
     is_batch_aware = True
     passes_through_input = False
@@ -406,8 +410,10 @@ class BatchOutlierAnnotator(BaseTransform):
             self._field("missing_count"): stats.missing_count,
             self._field("non_finite_count"): stats.non_finite_count,
             self._field("skipped_count"): stats.skipped_count,
-            self._field("missing_indices"): stats.missing_indices,
-            self._field("non_finite_indices"): stats.non_finite_indices,
+            self._field("missing_indices"): stats.missing_indices[:_MAX_INDEX_DETAIL_ITEMS],
+            self._field("missing_indices_truncated"): len(stats.missing_indices) > _MAX_INDEX_DETAIL_ITEMS,
+            self._field("non_finite_indices"): stats.non_finite_indices[:_MAX_INDEX_DETAIL_ITEMS],
+            self._field("non_finite_indices_truncated"): len(stats.non_finite_indices) > _MAX_INDEX_DETAIL_ITEMS,
             self._field("mean"): stats.mean,
             self._field("median"): stats.median,
             self._field("stdev"): stats.stdev,

--- a/src/elspeth/plugins/transforms/batch_paired_preference.py
+++ b/src/elspeth/plugins/transforms/batch_paired_preference.py
@@ -19,12 +19,16 @@ from elspeth.plugins.infrastructure.base import BaseTransform
 from elspeth.plugins.infrastructure.config_base import TransformDataConfig
 from elspeth.plugins.infrastructure.results import TransformResult
 from elspeth.plugins.transforms._scalar_buckets import (
-    append_unique_bucket_value,
+    ScalarBucketKey,
+    append_unique_bucket_value_with_seen,
+    hashable_scalar_bucket_key,
     same_scalar_bucket_value,
     scalar_bucket_contains,
 )
 
 type BatchPairedPreferenceRow = dict[str, object]
+
+_MAX_INCOMPLETE_PAIR_DETAILS = 1_000
 
 _PAIRED_OUTPUT_FIELDS = frozenset(
     {
@@ -35,6 +39,8 @@ _PAIRED_OUTPUT_FIELDS = frozenset(
         "confidence_95_high",
         "confidence_95_low",
         "incomplete_pair_count",
+        "incomplete_pairs",
+        "incomplete_pairs_truncated",
         "loss_rate",
         "losses",
         "mean_paired_delta",
@@ -62,6 +68,22 @@ class _ScoreEntry:
     score: int | float | None
     missing: bool = False
     non_finite: bool = False
+
+
+@dataclass(slots=True)
+class _PairBucket:
+    pair_id: Any
+    entries: list[_ScoreEntry]
+    entry_by_variant: dict[ScalarBucketKey, _ScoreEntry]
+    unhashable_entries: list[_ScoreEntry]
+
+    def append(self, entry: _ScoreEntry) -> None:
+        self.entries.append(entry)
+        key = hashable_scalar_bucket_key(entry.variant)
+        if key is None:
+            self.unhashable_entries.append(entry)
+            return
+        self.entry_by_variant.setdefault(key, entry)
 
 
 class BatchPairedPreferenceConfig(TransformDataConfig):
@@ -116,7 +138,7 @@ class BatchPairedPreference(BaseTransform):
     name = "batch_paired_preference"
     determinism = Determinism.DETERMINISTIC
     plugin_version = "1.0.0"
-    source_file_hash: str | None = "sha256:48862b640e0de744"
+    source_file_hash: str | None = "sha256:e31202f12d98886f"
     config_model = BatchPairedPreferenceConfig
     is_batch_aware = True
 
@@ -216,28 +238,56 @@ class BatchPairedPreference(BaseTransform):
 
         return _ScoreEntry(variant=variant, score=raw_score)
 
-    def _collect_pairs(self, rows: list[PipelineRow]) -> tuple[list[tuple[Any, list[_ScoreEntry]]], list[Any]]:
-        pairs: list[tuple[Any, list[_ScoreEntry]]] = []
+    def _collect_pairs(self, rows: list[PipelineRow]) -> tuple[list[_PairBucket], list[Any]]:
+        pairs: list[_PairBucket] = []
+        pair_indexes: dict[ScalarBucketKey, int] = {}
+        unhashable_pair_indexes: list[tuple[Any, int]] = []
         variants: list[Any] = []
+        variant_keys: set[ScalarBucketKey] = set()
+        unhashable_variants: list[Any] = []
 
         for row_index, row in enumerate(rows):
             pair_id = row[self._pair_field]
             entry = self._score_entry_for(row, row_index=row_index)
 
-            append_unique_bucket_value(variants, entry.variant)
+            append_unique_bucket_value_with_seen(
+                variants,
+                entry.variant,
+                seen_hashable=variant_keys,
+                seen_unhashable=unhashable_variants,
+            )
 
-            for existing_pair, entries in pairs:
-                if same_scalar_bucket_value(pair_id, existing_pair):
-                    entries.append(entry)
-                    break
+            pair_key = hashable_scalar_bucket_key(pair_id)
+            if pair_key is not None:
+                pair_index = pair_indexes.get(pair_key)
             else:
-                pairs.append((pair_id, [entry]))
+                pair_index = next(
+                    (
+                        existing_index
+                        for existing_pair, existing_index in unhashable_pair_indexes
+                        if same_scalar_bucket_value(pair_id, existing_pair)
+                    ),
+                    None,
+                )
+
+            if pair_index is None:
+                pair_index = len(pairs)
+                pairs.append(_PairBucket(pair_id=pair_id, entries=[], entry_by_variant={}, unhashable_entries=[]))
+                if pair_key is not None:
+                    pair_indexes[pair_key] = pair_index
+                else:
+                    unhashable_pair_indexes.append((pair_id, pair_index))
+
+            pairs[pair_index].append(entry)
 
         return pairs, variants
 
     @staticmethod
-    def _find_variant_entry(entries: list[_ScoreEntry], variant: Any) -> _ScoreEntry | None:
-        for entry in entries:
+    def _find_variant_entry(pair: _PairBucket, variant: Any) -> _ScoreEntry | None:
+        key = hashable_scalar_bucket_key(variant)
+        if key is not None:
+            return pair.entry_by_variant.get(key)
+        for entry in pair.unhashable_entries:
             if same_scalar_bucket_value(entry.variant, variant):
                 return entry
         return None
@@ -261,7 +311,7 @@ class BatchPairedPreference(BaseTransform):
     def _comparison_for(
         self,
         *,
-        pairs: list[tuple[Any, list[_ScoreEntry]]],
+        pairs: list[_PairBucket],
         baseline_variant: Any,
         variant: Any,
         batch_size: int,
@@ -270,23 +320,28 @@ class BatchPairedPreference(BaseTransform):
         variant_scores: list[int | float] = []
         deltas: list[float] = []
         incomplete_pairs: list[Any] = []
+        incomplete_pair_count = 0
         missing_score_count = 0
         non_finite_score_count = 0
         wins = 0
         losses = 0
         ties = 0
 
-        for pair_id, entries in pairs:
-            baseline = self._find_variant_entry(entries, baseline_variant)
-            candidate = self._find_variant_entry(entries, variant)
+        for pair in pairs:
+            baseline = self._find_variant_entry(pair, baseline_variant)
+            candidate = self._find_variant_entry(pair, variant)
             if baseline is None or candidate is None:
-                incomplete_pairs.append(pair_id)
+                incomplete_pair_count += 1
+                if len(incomplete_pairs) < _MAX_INCOMPLETE_PAIR_DETAILS:
+                    incomplete_pairs.append(pair.pair_id)
                 continue
 
             missing_score_count += int(baseline.missing) + int(candidate.missing)
             non_finite_score_count += int(baseline.non_finite) + int(candidate.non_finite)
             if baseline.score is None or candidate.score is None:
-                incomplete_pairs.append(pair_id)
+                incomplete_pair_count += 1
+                if len(incomplete_pairs) < _MAX_INCOMPLETE_PAIR_DETAILS:
+                    incomplete_pairs.append(pair.pair_id)
                 continue
 
             try:
@@ -349,7 +404,8 @@ class BatchPairedPreference(BaseTransform):
             "batch_size": batch_size,
             "total_pair_count": len(pairs),
             "compared_pair_count": compared_count,
-            "incomplete_pair_count": len(incomplete_pairs),
+            "incomplete_pair_count": incomplete_pair_count,
+            "incomplete_pairs_truncated": incomplete_pair_count > len(incomplete_pairs),
             "missing_score_count": missing_score_count,
             "non_finite_score_count": non_finite_score_count,
             "baseline_mean": baseline_mean,

--- a/tests/unit/plugins/transforms/test_batch_drift_compare.py
+++ b/tests/unit/plugins/transforms/test_batch_drift_compare.py
@@ -209,6 +209,26 @@ class TestBatchDriftCompare:
         assert shifts[("int", 1)]["baseline_count"] == 0
         assert shifts[("int", 1)]["cohort_count"] == 1
 
+    def test_categorical_detail_lists_are_bounded_for_high_cardinality_batches(self, ctx: PluginContext) -> None:
+        from elspeth.plugins.transforms.batch_drift_compare import _MAX_CATEGORY_DETAIL_ITEMS, BatchDriftCompare
+
+        transform = BatchDriftCompare(
+            {"schema": DYNAMIC_SCHEMA, "cohort_field": "cohort", "value_field": "label", "value_type": "categorical"}
+        )
+        rows = [_make_row({"cohort": "baseline", "label": "baseline-only"})]
+        rows.extend(_make_row({"cohort": "current", "label": f"category-{index}"}) for index in range(_MAX_CATEGORY_DETAIL_ITEMS + 1))
+
+        result = transform.process(rows, ctx)
+
+        assert result.status == "success"
+        assert result.row is not None
+        assert result.row["category_shift_count"] == _MAX_CATEGORY_DETAIL_ITEMS + 2
+        assert len(result.row["category_shifts"]) == _MAX_CATEGORY_DETAIL_ITEMS
+        assert result.row["category_shifts_truncated"] is True
+        assert result.row["new_category_count"] == _MAX_CATEGORY_DETAIL_ITEMS + 1
+        assert len(result.row["new_categories"]) == _MAX_CATEGORY_DETAIL_ITEMS
+        assert result.row["new_categories_truncated"] is True
+
     def test_numeric_non_numeric_values_raise_type_error(self, ctx: PluginContext) -> None:
         from elspeth.plugins.transforms.batch_drift_compare import BatchDriftCompare
 

--- a/tests/unit/plugins/transforms/test_batch_outlier_annotator.py
+++ b/tests/unit/plugins/transforms/test_batch_outlier_annotator.py
@@ -98,6 +98,23 @@ class TestBatchOutlierAnnotator:
             assert row["outlier_missing_indices"] == (1,)
             assert row["outlier_non_finite_indices"] == (2,)
 
+    def test_skipped_index_details_are_bounded_per_output_row(self, ctx: PluginContext) -> None:
+        from elspeth.plugins.transforms.batch_outlier_annotator import _MAX_INDEX_DETAIL_ITEMS, BatchOutlierAnnotator
+
+        transform = BatchOutlierAnnotator({"schema": DYNAMIC_SCHEMA, "value_field": "score"})
+        rows = [_make_row({"id": "finite", "score": 10.0})]
+        rows.extend(_make_row({"id": f"missing-{index}", "score": None}) for index in range(_MAX_INDEX_DETAIL_ITEMS + 1))
+
+        result = transform.process(rows, ctx)
+
+        assert result.status == "success"
+        assert result.row is not None
+        assert result.row["outlier_missing_count"] == _MAX_INDEX_DETAIL_ITEMS + 1
+        assert len(result.row["outlier_missing_indices"]) == _MAX_INDEX_DETAIL_ITEMS
+        assert result.row["outlier_missing_indices_truncated"] is True
+        assert result.row["outlier_non_finite_indices"] == ()
+        assert result.row["outlier_non_finite_indices_truncated"] is False
+
     def test_backward_invariant_probe_exercises_dropped_row_shape(self, ctx: PluginContext) -> None:
         from elspeth.plugins.transforms.batch_outlier_annotator import BatchOutlierAnnotator
 
@@ -236,8 +253,10 @@ class TestBatchOutlierAnnotatorConfig:
                 "outlier_median",
                 "outlier_missing_count",
                 "outlier_missing_indices",
+                "outlier_missing_indices_truncated",
                 "outlier_non_finite_count",
                 "outlier_non_finite_indices",
+                "outlier_non_finite_indices_truncated",
                 "outlier_reason",
                 "outlier_robust_z_score",
                 "outlier_robust_z_threshold",

--- a/tests/unit/plugins/transforms/test_batch_paired_preference.py
+++ b/tests/unit/plugins/transforms/test_batch_paired_preference.py
@@ -197,6 +197,28 @@ class TestBatchPairedPreference:
         assert result.reason["operation"] == "paired_delta"
         assert result.reason["group_value"] == "B"
 
+    def test_incomplete_pair_details_are_bounded_for_high_cardinality_batches(self, ctx: PluginContext) -> None:
+        from elspeth.plugins.transforms.batch_paired_preference import _MAX_INCOMPLETE_PAIR_DETAILS, BatchPairedPreference
+
+        transform = BatchPairedPreference(
+            {"schema": DYNAMIC_SCHEMA, "pair_field": "case_id", "variant_field": "variant", "score_field": "score"}
+        )
+        rows = [
+            _make_row({"case_id": "complete", "variant": "A", "score": 0.5}),
+            _make_row({"case_id": "complete", "variant": "B", "score": 0.6}),
+        ]
+        rows.extend(
+            _make_row({"case_id": f"incomplete-{index}", "variant": "A", "score": 0.5}) for index in range(_MAX_INCOMPLETE_PAIR_DETAILS + 1)
+        )
+
+        result = transform.process(rows, ctx)
+
+        assert result.status == "success"
+        assert result.row is not None
+        assert result.row["incomplete_pair_count"] == _MAX_INCOMPLETE_PAIR_DETAILS + 1
+        assert len(result.row["incomplete_pairs"]) == _MAX_INCOMPLETE_PAIR_DETAILS
+        assert result.row["incomplete_pairs_truncated"] is True
+
     def test_non_numeric_scores_raise_type_error(self, ctx: PluginContext) -> None:
         from elspeth.plugins.transforms.batch_paired_preference import BatchPairedPreference
 
@@ -310,6 +332,8 @@ class TestBatchPairedPreferenceConfig:
                 "confidence_95_high",
                 "confidence_95_low",
                 "incomplete_pair_count",
+                "incomplete_pairs",
+                "incomplete_pairs_truncated",
                 "loss_rate",
                 "losses",
                 "mean_paired_delta",


### PR DESCRIPTION
### Motivation
- Prevent authenticated users from causing CPU/memory amplification and DoS by submitting high-cardinality or very large aggregation batches to the new batch QA transforms.
- Make expensive operations (KS computation, unique-value collection, pair/variant grouping, repeated index emission) linear or bounded in output size while preserving existing semantics (type-aware bucket equality, counts, and audit fields).

### Description
- Add type-aware, hash-backed bucket helpers (`_scalar_buckets.py`) and use them to deduplicate cohorts/categories/variants with O(1) tracking for hashable values and safe fallbacks for unhashable values.
- Replace the O(n^2) KS implementation in `BatchDriftCompare` with a linear two-pointer scan over the two sorted value lists and bound categorical detail payloads using a `_MAX_CATEGORY_DETAIL_ITEMS` limit while exposing truncation flags and precise counts.
- Rework `BatchPairedPreference` to index pairs and variants with type-aware keys and cap emitted `incomplete_pairs` detail while preserving `incomplete_pair_count` so counts remain accurate but detail size is bounded.
- Limit per-row repeated index lists in `BatchOutlierAnnotator` by slicing `missing_indices`/`non_finite_indices` to `_MAX_INDEX_DETAIL_ITEMS` and adding per-field truncated flags, and add focused regression tests for the new bounded behaviors.

### Testing
- Ran `ruff check` and formatting on the modified modules and tests, which passed.
- Ran `python -m py_compile` over modified modules and related tests to ensure syntax validity, which passed.
- Verified plugin `source_file_hash` values by recomputing with the linter helper and asserting the declared hashes match the computed values, and performed manual runtime smoke checks exercising KS, categorical truncation, paired incomplete-pair truncation, and outlier index truncation, all of which passed.
- Attempted to run the targeted unit tests under `pytest`, but the run was blocked in this sandbox by a missing dev dependency (`hypothesis`) that could not be fetched due to network tunnel failures, so full pytest execution was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2281104978832395a22adc110414cc)