### PR TITLE
fix(composer): reject current-directory sink paths

### DIFF
--- a/src/elspeth/web/composer/guided/stage_transitions.py
+++ b/src/elspeth/web/composer/guided/stage_transitions.py
@@ -1070,6 +1070,8 @@ def canonical_sink_local_paths(options: Mapping[str, Any]) -> dict[str, Any]:
         if type(value) is not str or not value or value.startswith(BLOB_REF_PATH_PREFIX):
             continue
         raw = PurePosixPath(value)
+        if not raw.parts:
+            raise ValueError(f"option {key!r} must name a path, not the current directory")
         if ".." in raw.parts:
             raise ValueError(
                 f"option {key!r} must not contain '..' path segments; give a path like 'results.json' or 'reports/results.json'"

--- a/tests/unit/web/composer/test_set_pipeline_candidate.py
+++ b/tests/unit/web/composer/test_set_pipeline_candidate.py
@@ -2160,6 +2160,21 @@ def test_parent_traversal_sink_path_still_rejected(tmp_path: Path) -> None:
     assert ".." in ((candidate.result.data or {}).get("error") or "")
 
 
+@pytest.mark.parametrize("path", [".", "./"])
+def test_current_directory_sink_path_returns_validation_failure(tmp_path: Path, path: str) -> None:
+    args = _ab_multi_query_args(tmp_path)
+    args["outputs"][0]["options"]["path"] = path
+    (tmp_path / "outputs").mkdir(exist_ok=True)
+    context = _operator_profile_view(tmp_path)
+
+    candidate = build_set_pipeline_candidate(args, _empty_state(), context)
+
+    assert candidate.acceptable is False
+    assert candidate.result.success is False
+    assert (candidate.result.data or {}).get("error_code") == "plugin_options_invalid"
+    assert "current directory" in ((candidate.result.data or {}).get("error") or "")
+
+
 def _scrape_cleanup_args(tmp_path: Path) -> dict[str, Any]:
     """web_scrape -> field_mapper(select_only) chain that DROPS the raw fields
     without staging the drop_raw_html_fields review requirement."""


### PR DESCRIPTION
### Motivation

- Prevent an IndexError when `PurePosixPath('.')` or `PurePosixPath('./')` produce an empty `parts` tuple and the canonicalizer indexed `raw.parts[0]`, which caused an unhandled crash instead of a recoverable validation failure.

### Description

- Add an explicit guard in `canonical_sink_local_paths` to raise `ValueError` when `raw.parts` is empty with the message that the option must not name the current directory, avoiding an `IndexError` and preserving the plugin validation path (`src/elspeth/web/composer/guided/stage_transitions.py`).
- Add a regression test `test_current_directory_sink_path_returns_validation_failure` covering both `'.'` and `'./'` to assert the candidate is rejected with `error_code == "plugin_options_invalid"` (`tests/unit/web/composer/test_set_pipeline_candidate.py`).
- The change keeps existing handling for absolute paths, parent-traversal (`..`), and normal relatives intact.

### Testing

- Ran `ruff check src/elspeth/web/composer/guided/stage_transitions.py tests/unit/web/composer/test_set_pipeline_candidate.py` which passed. 
- Ran `ruff format --check src/elspeth/web/composer/guided/stage_transitions.py tests/unit/web/composer/test_set_pipeline_candidate.py` which passed, and `python -m compileall -q src/elspeth/web/composer/guided/stage_transitions.py tests/unit/web/composer/test_set_pipeline_candidate.py` which also passed, and `git diff --check` which found no issues. 
- Attempted to run the targeted `pytest` selection, but test execution could not complete because the environment Python lacks `hypothesis` and the project virtualenv lacked `pytest`, so the new regression test has been added but full `pytest` verification could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65c3fdf96c8323b494f7535d0098bc)