### PR TITLE
fix(composer): retain blobs referenced by guided pipeline proposals

### DIFF
--- a/src/elspeth/web/sessions/proposal_blob_refs.py
+++ b/src/elspeth/web/sessions/proposal_blob_refs.py
@@ -19,6 +19,58 @@ _TOP_LEVEL_BLOB_TOOLS = frozenset(
     }
 )
 _BLOB_REFERENCE_TOOLS = _TOP_LEVEL_BLOB_TOOLS | {"set_pipeline"}
+_PIPELINE_BLOB_PATH_KEYS = ("path", "file")
+
+
+def _pipeline_blob_reference_ids(arguments: Mapping[str, Any]) -> tuple[str, ...]:
+    """Extract blob custody from legacy and guided pipeline source shapes."""
+    references: list[str] = []
+    source = arguments["source"] if "source" in arguments else None
+    if source is not None:
+        if type(source) is not dict:
+            raise ValueError("set_pipeline source must be a mapping when present")
+        value = source["blob_id"] if "blob_id" in source else None
+        if value is not None:
+            if type(value) is not str or not value:
+                raise ValueError("set_pipeline source.blob_id must be a non-empty string when present")
+            references.append(value)
+
+    sources = arguments["sources"] if "sources" in arguments else None
+    if sources is None:
+        return tuple(references)
+    if type(sources) is not dict:
+        raise ValueError("set_pipeline sources must be a mapping when present")
+    for source_name, guided_source in sources.items():
+        if type(source_name) is not str or not source_name or type(guided_source) is not dict:
+            raise ValueError("set_pipeline sources must contain non-empty string names and source mappings")
+        options = guided_source["options"] if "options" in guided_source else None
+        if options is None:
+            continue
+        if type(options) is not dict:
+            raise ValueError(f"set_pipeline sources[{source_name!r}].options must be a mapping when present")
+        source_references: set[str] = set()
+        if "blob_ref" in options:
+            blob_ref = options["blob_ref"]
+            if type(blob_ref) is not str or not blob_ref:
+                raise ValueError(
+                    f"set_pipeline sources[{source_name!r}].options.blob_ref must be a non-empty string when present"
+                )
+            source_references.add(blob_ref)
+        for key in _PIPELINE_BLOB_PATH_KEYS:
+            value = options[key] if key in options else None
+            if type(value) is str and value.startswith("blob:"):
+                blob_id = value.removeprefix("blob:")
+                if not blob_id:
+                    raise ValueError(
+                        f"set_pipeline sources[{source_name!r}].options.{key} blob sentinel must contain a blob id"
+                    )
+                source_references.add(blob_id)
+        if len(source_references) > 1:
+            raise ValueError(f"set_pipeline sources[{source_name!r}] blob custody fields disagree")
+        for blob_id in source_references:
+            if blob_id not in references:
+                references.append(blob_id)
+    return tuple(references)
 
 
 def proposal_blob_reference_ids(tool_name: str, arguments: Mapping[str, Any]) -> tuple[str, ...]:
@@ -31,13 +83,7 @@ def proposal_blob_reference_ids(tool_name: str, arguments: Mapping[str, Any]) ->
         return ()
 
     if tool_name == "set_pipeline":
-        source = arguments["source"] if "source" in arguments else None
-        if source is None:
-            return ()
-        if type(source) is not dict:
-            raise ValueError("set_pipeline source must be a mapping when present")
-        value = source["blob_id"] if "blob_id" in source else None
-        field_name = "source.blob_id"
+        return _pipeline_blob_reference_ids(arguments)
     else:
         value = arguments["blob_id"] if "blob_id" in arguments else None
         field_name = "blob_id"

--- a/tests/unit/web/sessions/test_proposal_blob_refs.py
+++ b/tests/unit/web/sessions/test_proposal_blob_refs.py
@@ -1,0 +1,47 @@
+"""Tests for the closed proposal-to-blob custody contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from elspeth.web.sessions.proposal_blob_refs import proposal_blob_reference_ids
+
+
+def test_guided_set_pipeline_extracts_plural_source_blob_authority() -> None:
+    arguments = {
+        "sources": {
+            "orders": {"options": {"blob_ref": "blob-one", "path": "blob:blob-one"}},
+            "customers": {"options": {"file": "blob:blob-two"}},
+            "manual": {"options": {"path": "/operator/input.csv"}},
+        }
+    }
+
+    assert proposal_blob_reference_ids("set_pipeline", arguments) == ("blob-one", "blob-two")
+
+
+def test_guided_set_pipeline_deduplicates_shared_blob_authority() -> None:
+    arguments = {
+        "sources": {
+            "first": {"options": {"blob_ref": "shared"}},
+            "second": {"options": {"path": "blob:shared"}},
+        }
+    }
+
+    assert proposal_blob_reference_ids("set_pipeline", arguments) == ("shared",)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"blob_ref": 1},
+        {"path": "blob:"},
+        {"blob_ref": "one", "file": "blob:two"},
+    ],
+)
+def test_guided_set_pipeline_rejects_malformed_blob_authority(options: dict[str, object]) -> None:
+    with pytest.raises(ValueError, match="set_pipeline"):
+        proposal_blob_reference_ids("set_pipeline", {"sources": {"input": {"options": options}}})
+
+
+def test_set_pipeline_preserves_legacy_singular_blob_authority() -> None:
+    assert proposal_blob_reference_ids("set_pipeline", {"source": {"blob_id": "legacy"}}) == ("legacy",)


### PR DESCRIPTION
### Motivation
- Guided planner now binds reviewed source options into the plural `sources` shape, but the proposal-to-blob extractor only recognized the legacy singular `source.blob_id`, allowing blobs referenced by pending guided proposals to be deleted.
- The change restores custody/retention semantics so guided `set_pipeline` proposals block deletion of blobs they depend on and preserve proposal integrity.

### Description
- Add `_pipeline_blob_reference_ids` and `_PIPELINE_BLOB_PATH_KEYS` to extract blob custody from both legacy `source.blob_id` and guided `sources[*].options` shapes.
- Route `set_pipeline` through the new extractor in `proposal_blob_reference_ids` so validation and pending-proposal checks see guided references.
- Recognize `options.blob_ref` and `options.path`/`options.file` `blob:<id>` sentinels, deduplicate shared references, and fail closed on malformed or conflicting custody fields.
- Add focused regression tests in `tests/unit/web/sessions/test_proposal_blob_refs.py` covering plural extraction, deduplication, malformed authority, and legacy singular compatibility.

### Testing
- `ruff check src/elspeth/web/sessions/proposal_blob_refs.py tests/unit/web/sessions/test_proposal_blob_refs.py` passed.
- `python -m py_compile src/elspeth/web/sessions/proposal_blob_refs.py tests/unit/web/sessions/test_proposal_blob_refs.py` passed.
- `git diff --check` and repository status inspections reported a clean working tree after the change.
- `pytest -q tests/unit/web/sessions/test_proposal_blob_refs.py` was blocked by a missing test dependency (`hypothesis`) in the environment and could not be executed here.
- `uv run --extra dev pytest -q tests/unit/web/sessions/test_proposal_blob_refs.py` was blocked by a network/download failure when fetching a test dependency (`wrapt`).
- `mypy src/elspeth/web/sessions/proposal_blob_refs.py` could not complete due to the configured `pydantic.mypy` plugin not being available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65c3ff276c8323a842097c84d7b6f7)