### PR TITLE
Fix malformed interpretation requirement handling

### DIFF
--- a/src/elspeth/web/composer/tools/_common.py
+++ b/src/elspeth/web/composer/tools/_common.py
@@ -1658,13 +1658,29 @@ def _resolver_owned_interpretation_requirement_error(
     LLM-SUPPLIED delta (full options on a create, the ``patch`` on a merge) so a
     legitimately-resolved requirement already in stored state is not re-flagged.
     """
-    requirements_value = options[INTERPRETATION_REQUIREMENTS_KEY] if INTERPRETATION_REQUIREMENTS_KEY in options else None
-    if not isinstance(requirements_value, (list, tuple)):
+    if INTERPRETATION_REQUIREMENTS_KEY not in options:
         return None
+    requirements_value = options[INTERPRETATION_REQUIREMENTS_KEY]
+    if not isinstance(requirements_value, (list, tuple)):
+        return f"{tool_name} options.{INTERPRETATION_REQUIREMENTS_KEY} must be a list of review entry objects."
 
     for index, requirement in enumerate(requirements_value):
         if not isinstance(requirement, Mapping):
-            continue
+            return (
+                f"{tool_name} options.{INTERPRETATION_REQUIREMENTS_KEY}[{index}] must be a review entry object "
+                "with non-empty string fields kind, user_term, and draft."
+            )
+        malformed_fields = [
+            field
+            for field in ("kind", "user_term", "draft")
+            if not isinstance(requirement.get(field), str) or not requirement[field].strip()
+        ]
+        if malformed_fields:
+            field_names = ", ".join(malformed_fields)
+            return (
+                f"{tool_name} options.{INTERPRETATION_REQUIREMENTS_KEY}[{index}] has invalid field(s): {field_names}. "
+                "Composer-authored review entries require non-empty string fields kind, user_term, and draft."
+            )
         status = requirement["status"] if "status" in requirement else None
         if status not in (None, "pending"):
             return (

--- a/tests/unit/web/composer/test_tools.py
+++ b/tests/unit/web/composer/test_tools.py
@@ -7803,6 +7803,42 @@ def _llm_options_with_forged_resolved_reviews(api_key: Any) -> dict[str, Any]:
     return options
 
 
+@pytest.mark.parametrize(
+    "malformed_requirement",
+    [
+        {"status": "pending", "user_term": "llm_prompt_template:classify", "draft": "Classify the current row."},
+        {"kind": "llm_prompt_template", "status": "pending", "user_term": 123, "draft": "Classify the current row."},
+    ],
+)
+def test_upsert_node_rejects_malformed_pending_interpretation_requirement(
+    malformed_requirement: dict[str, Any],
+) -> None:
+    """Malformed LLM-authored review rows fail at the tool boundary, not in backend surfacing."""
+    state = _empty_state()
+    options = _llm_options_with_api_key({"secret_ref": "OPENROUTER_API_KEY"})
+    options[INTERPRETATION_REQUIREMENTS_KEY] = [malformed_requirement]
+
+    result = execute_tool(
+        "upsert_node",
+        {
+            "id": "classify",
+            "node_type": "transform",
+            "plugin": "llm",
+            "input": "source_out",
+            "on_success": "main",
+            "on_error": "discard",
+            "options": options,
+        },
+        state,
+        _mock_catalog(),
+    )
+
+    assert result.success is False
+    assert result.updated_state is state
+    assert "interpretation_requirements[0]" in result.data["error"]
+    assert "invalid field(s)" in result.data["error"]
+
+
 def _assert_secret_wiring_contract_failure(
     result: ToolResult,
     original_state: CompositionState,


### PR DESCRIPTION
### Motivation

- A strict reader of `options.interpretation_requirements` raised hard on malformed entries authored via LLM tool calls, turning benign malformed input into 500s during backend auto-surfacing. 
- The intent is to enforce a write-boundary validation for composer-authoring inputs so malformed pending review rows are rejected early and do not crash downstream readers.

### Description

- Add write-boundary validation in `src/elspeth/web/composer/tools/_common.py` to reject non-list `interpretation_requirements` containers and non-mapping entries with a clear error string. 
- Validate each pending requirement entry carries non-empty string `kind`, `user_term`, and `draft` fields and return explainable tool-boundary errors before resolver-owned checks are evaluated. 
- Preserve and keep intact the existing protections against resolver-owned fields and resolved `status` values while surfacing earlier, clearer failures for malformed pending entries. 
- Add regression coverage in `tests/unit/web/composer/test_tools.py` that exercises `upsert_node` with malformed requirement shapes (missing `kind` and non-string `user_term`) and asserts the tool rejects the input without mutating state.

### Testing

- Ran formatting and lint checks with `uv run ruff format` and `uv run ruff check` on the modified files, and they passed. 
- Ran `git diff --check` and basic diffs to validate the patch shape with no whitespace errors. 
- Attempted the focused pytest invocation `uv run pytest tests/unit/web/composer/test_tools.py -k 'malformed_pending_interpretation_requirement' -q` but test collection failed due to the environment missing the `hypothesis` dependency. 
- Attempted `uv sync --extra dev` to install test deps but dependency installation was blocked by the environment network/proxy when downloading `pony==0.7.19`, so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d4cccc108323938b6473ea883484)