### PR TITLE
fix(cli): prevent payload chmod symlink race

### DIFF
--- a/src/elspeth/cli.py
+++ b/src/elspeth/cli.py
@@ -350,7 +350,15 @@ def _ensure_output_directories(
             # mode is still filtered through umask, so normalize only the root
             # this preflight creates instead of weakening validation later.
             payload_path.mkdir(mode=0o700, parents=True, exist_ok=False)
-            os.chmod(payload_path, 0o700)
+            if os.name != "nt":
+                # Bind permission normalization to the directory we created.
+                # O_NOFOLLOW prevents a raced symlink replacement from redirecting
+                # fchmod() to another path owned by this user.
+                payload_fd = os.open(payload_path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+                try:
+                    os.fchmod(payload_fd, 0o700)
+                finally:
+                    os.close(payload_fd)
         except FileExistsError as e:
             if not payload_path.exists():
                 errors.append(f"Cannot create payload store directory: {payload_path.resolve()}\n  Error: {e}")

--- a/tests/unit/cli/test_output_directories.py
+++ b/tests/unit/cli/test_output_directories.py
@@ -32,3 +32,32 @@ def test_ensure_output_directories_creates_payload_store_owner_only_under_permis
     assert errors == []
     assert stat.S_IMODE(payload_path.stat().st_mode) == 0o700
     FilesystemPayloadStore(payload_path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX O_NOFOLLOW semantics are required for this regression")
+def test_ensure_output_directories_does_not_chmod_raced_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload_path = tmp_path / "payloads"
+    victim_path = tmp_path / "victim"
+    victim_path.write_text("preserve my permissions", encoding="utf-8")
+    victim_path.chmod(0o644)
+    config = ElspethSettings(
+        sources={"primary": {"plugin": "csv", "on_success": "output"}},
+        sinks={"output": {"plugin": "json", "on_write_failure": "discard"}},
+        landscape={"url": f"sqlite:///{tmp_path / 'state' / 'audit.db'}"},
+        payload_store={"base_path": payload_path},
+    )
+    original_mkdir = Path.mkdir
+
+    def mkdir_then_swap(path: Path, *args: object, **kwargs: object) -> None:
+        original_mkdir(path, *args, **kwargs)
+        if path == payload_path:
+            path.rmdir()
+            path.symlink_to(victim_path)
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_then_swap)
+
+    errors = _ensure_output_directories(config)
+
+    assert errors
+    assert payload_path.is_symlink()
+    assert stat.S_IMODE(victim_path.stat().st_mode) == 0o644


### PR DESCRIPTION
### Motivation

- The preflight created the payload directory with `mkdir()` and then called `os.chmod(payload_path, 0o700)`, which introduced a TOCTOU where a raced symlink replacement could cause `chmod` to affect an attacker-controlled target.  

### Description

- On POSIX systems replace the pathname `os.chmod()` with opening the created directory using `os.open(..., os.O_DIRECTORY | os.O_NOFOLLOW)` and calling `os.fchmod()` on the descriptor, then close the descriptor to bind the permission normalization to the directory we created.  
- Preserve existing behavior on Windows by skipping the descriptor-based step (`os.name != "nt"`).  
- Add a deterministic regression test `test_ensure_output_directories_does_not_chmod_raced_symlink` that monkeypatches `Path.mkdir` to swap the new directory for a symlink and verifies the victim target's mode is unchanged.  
- Files modified: `src/elspeth/cli.py` and `tests/unit/cli/test_output_directories.py`.

### Testing

- Ran `uv run ruff format --check` and `uv run ruff check` against the modified files, and both checks passed.  
- Attempted to run `pytest tests/unit/cli/test_output_directories.py`, but the test run failed due to `ModuleNotFoundError: No module named 'hypothesis'` in the environment, so the full test could not be executed here.  
- Attempted to sync dev dependencies (`uv sync --extra dev --frozen`) to enable tests, but dependency resolution failed to fetch required wheels from PyPI in this environment, preventing a complete test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d4ce670883238cf51bbc2d7d746b)