### PR TITLE
fix: restrict payload store on read-only repositories

### DIFF
--- a/src/elspeth/contracts/payload_store.py
+++ b/src/elspeth/contracts/payload_store.py
@@ -40,6 +40,19 @@ class PayloadNotFoundError(Exception):
 
 
 @runtime_checkable
+class PayloadReader(Protocol):
+    """Read-only access to content-addressable payload storage."""
+
+    def retrieve(self, content_hash: str) -> bytes:
+        """Retrieve content by hash with integrity verification."""
+        ...
+
+    def exists(self, content_hash: str) -> bool:
+        """Return whether content exists for the supplied hash."""
+        ...
+
+
+@runtime_checkable
 class PayloadStore(Protocol):
     """Protocol for payload storage backends.
 

--- a/src/elspeth/core/landscape/factory.py
+++ b/src/elspeth/core/landscape/factory.py
@@ -46,7 +46,7 @@ from elspeth.core.landscape.scheduler_repository import TokenSchedulerRepository
 
 if TYPE_CHECKING:
     from elspeth.contracts import Run, SecretResolution
-    from elspeth.contracts.payload_store import PayloadStore
+    from elspeth.contracts.payload_store import PayloadReader, PayloadStore
     from elspeth.core.landscape.run_lifecycle_repository import (
         RunSourceFieldResolutionRecord,
         RunSourceLifecycleRecord,
@@ -201,6 +201,21 @@ class ExecutionReadRepository:
         return self._repo.get_artifacts(*args, **kwargs)
 
 
+class PayloadStoreReadRepository:
+    """Read-only capability view over a payload store."""
+
+    __slots__ = ("_store",)
+
+    def __init__(self, store: PayloadStore) -> None:
+        self._store = store
+
+    def retrieve(self, content_hash: str) -> bytes:
+        return self._store.retrieve(content_hash)
+
+    def exists(self, content_hash: str) -> bool:
+        return self._store.exists(content_hash)
+
+
 class LandscapeReadRepositories:
     """Typed read repository surface for inspection-only Landscape callers."""
 
@@ -223,7 +238,7 @@ class LandscapeReadRepositories:
         query: QueryRepository,
         run_status_projection: AuditRunStatusProjection,
         barrier_restore: BarrierRestoreReadModel,
-        payload_store: PayloadStore | None,
+        payload_store: PayloadReader | None,
     ) -> None:
         self.run_lifecycle = run_lifecycle
         self.data_flow = data_flow
@@ -263,6 +278,7 @@ class LandscapeWriteRepositories:
         scheduler: TokenSchedulerRepository,
         run_coordination: RunCoordinationRepository,
         audit_export_snapshots: AuditExportSnapshotRepository,
+        payload_store: PayloadStore | None,
     ) -> None:
         self.read = read
         self.run_lifecycle = run_lifecycle
@@ -272,7 +288,7 @@ class LandscapeWriteRepositories:
         self.query = read.query
         self.run_status_projection = read.run_status_projection
         self.barrier_restore = read.barrier_restore
-        self.payload_store = read.payload_store
+        self.payload_store = payload_store
         self.scheduler = scheduler
         self.run_coordination = run_coordination
         self.audit_export_snapshots = audit_export_snapshots
@@ -383,7 +399,7 @@ class RecorderFactory:
             query=query,
             run_status_projection=run_status_projection,
             barrier_restore=barrier_restore,
-            payload_store=payload_store,
+            payload_store=PayloadStoreReadRepository(payload_store) if payload_store is not None else None,
         )
 
     def __init__(self, db: LandscapeDB, *, payload_store: PayloadStore | None = None) -> None:
@@ -546,7 +562,7 @@ class RecorderFactory:
             query=self._query,
             run_status_projection=self._run_status_projection,
             barrier_restore=self._barrier_restore,
-            payload_store=self._payload_store,
+            payload_store=PayloadStoreReadRepository(self._payload_store) if self._payload_store is not None else None,
         )
 
     def write_repositories(self) -> LandscapeWriteRepositories:
@@ -562,4 +578,5 @@ class RecorderFactory:
             scheduler=self.scheduler,
             run_coordination=self.run_coordination,
             audit_export_snapshots=self.audit_export_snapshots,
+            payload_store=self._payload_store,
         )

--- a/tests/unit/core/landscape/test_factory.py
+++ b/tests/unit/core/landscape/test_factory.py
@@ -117,6 +117,27 @@ class TestPayloadStore:
     def test_payload_store_defaults_to_none(self, factory: RecorderFactory) -> None:
         assert factory.payload_store is None
 
+    def test_read_repositories_expose_only_read_payload_operations(self) -> None:
+        db = LandscapeDB.in_memory()
+        payload_store = MockPayloadStore()
+        payload_ref = payload_store.store(b"audit evidence")
+
+        read_payloads = RecorderFactory(db, payload_store=payload_store).read_repositories().payload_store
+
+        assert read_payloads is not None
+        assert read_payloads.exists(payload_ref)
+        assert read_payloads.retrieve(payload_ref) == b"audit evidence"
+        assert not hasattr(read_payloads, "store")
+        assert not hasattr(read_payloads, "delete")
+
+    def test_write_repositories_retain_mutable_payload_store(self) -> None:
+        db = LandscapeDB.in_memory()
+        payload_store = MockPayloadStore()
+
+        write_repositories = RecorderFactory(db, payload_store=payload_store).write_repositories()
+
+        assert write_repositories.payload_store is payload_store
+
 
 class TestPluginAuditWriter:
     """Verify plugin_audit_writer() returns the adapter."""


### PR DESCRIPTION
### Motivation

- Prevent capability leakage where the read-only repository surface exposed a mutable `PayloadStore` allowing `store()`/`delete()` operations. 
- Ensure callers intentionally given only inspection capabilities cannot mutate or remove audit payload blobs. 
- Maintain existing writable behavior while enforcing a strict read-only contract for inspection surfaces.

### Description

- Add a `PayloadReader` protocol exposing only `retrieve()` and `exists()` to represent read-only payload capabilities in `src/elspeth/contracts/payload_store.py`. 
- Introduce `PayloadStoreReadRepository` as a small facade that wraps a mutable `PayloadStore` and only exposes read methods in `src/elspeth/core/landscape/factory.py`. 
- Return the `PayloadReader` view from `RecorderFactory.read_only()` / `RecorderFactory.read_repositories()` so `LandscapeReadRepositories.payload_store` is read-only. 
- Preserve the original mutable `PayloadStore` on the writable surface (`LandscapeWriteRepositories.payload_store`) so writers retain full functionality.

### Testing

- Ran `ruff check` on the modified files and they passed. 
- Verified Python source compiles via `python -m compileall` on the changed modules. 
- Ran `git diff --check` to ensure no whitespace/patch issues. 
- Attempted unit tests `pytest -q tests/unit/core/landscape/test_factory.py tests/unit/mcp/test_analyzer_read_only.py` but the environment is missing the `hypothesis` dependency so `pytest` did not complete; `mypy` was not fully runnable due to a missing `pydantic` plugin dependency in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d4d8fdac8323b24546992e0f13b1)