### PR TITLE
fix(azure): reject malformed Operation-Location ports

### DIFF
--- a/src/elspeth/plugins/transforms/azure/document_intelligence_result.py
+++ b/src/elspeth/plugins/transforms/azure/document_intelligence_result.py
@@ -52,6 +52,10 @@ def operation_location_host_matches(operation_url: str, endpoint: str) -> bool:
     try:
         op = urlparse(operation_url)
         ep = urlparse(endpoint)
+        # ParseResult.port performs validation lazily and can raise for malformed
+        # or out-of-range ports, so keep access inside the fail-closed guard.
+        op_port = op.port if op.port is not None else 443
+        ep_port = ep.port if ep.port is not None else 443
     except ValueError:
         return False
     if op.scheme != "https" or not op.hostname:
@@ -60,8 +64,6 @@ def operation_location_host_matches(operation_url: str, endpoint: str) -> bool:
         return False
     # Compare effective ports, normalizing the https default (443) so an explicit
     # ":443" matches an absent port. A same-host but attacker-port URL is rejected.
-    op_port = op.port if op.port is not None else 443
-    ep_port = ep.port if ep.port is not None else 443
     return op_port == ep_port
 
 

--- a/tests/unit/plugins/transforms/azure/test_document_intelligence_result.py
+++ b/tests/unit/plugins/transforms/azure/test_document_intelligence_result.py
@@ -66,6 +66,15 @@ def test_host_match_accepts_explicit_default_port() -> None:
     assert operation_location_host_matches("https://di.cognitiveservices.azure.com:443/analyzeResults/abc", _ENDPOINT)
 
 
+@pytest.mark.parametrize("port", ["invalid", "65536"])
+def test_host_match_rejects_malformed_operation_port(port: str) -> None:
+    assert not operation_location_host_matches(f"https://di.cognitiveservices.azure.com:{port}/analyzeResults/abc", _ENDPOINT)
+
+
+def test_host_match_rejects_malformed_endpoint_port() -> None:
+    assert not operation_location_host_matches(_OP, "https://di.cognitiveservices.azure.com:invalid")
+
+
 def test_host_match_rejects_garbage() -> None:
     assert not operation_location_host_matches("not a url", _ENDPOINT)
 


### PR DESCRIPTION
### Motivation
- A malformed `Operation-Location` port (non-numeric or out-of-range) could raise `ValueError` when `.port` is accessed and crash batch processing instead of failing the row as untrusted. 
- Harden host:port matching so that invalid ports are treated as untrusted rather than propagating an exception. 

### Description
- Move access to `ParseResult.port` into the existing `ValueError` guard in `operation_location_host_matches()` so malformed or out-of-range ports return `False` instead of raising. 
- Preserve current behavior of normalizing default HTTPS port `443` and matching host and effective port. 
- Add regression tests that assert rejection of non-numeric and out-of-range operation ports and a malformed configured endpoint port in `tests/unit/plugins/transforms/azure/test_document_intelligence_result.py`.

### Testing
- Ran lint/format and static checks: `uv run ruff check ...` and `uv run ruff format --check ...`, which passed after formatting. 
- Verified byte-compile sanity with `python -m compileall -q` and `git diff --check`, both successful. 
- Attempted to run the targeted `pytest` collection for the Azure transform tests but collection could not start because the `hypothesis` dev dependency was not installable in this environment, so full pytest run is blocked by the environment rather than the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d4ccd31c83238c8d25d2ca65e38a)