### PR TITLE
Classify Dataverse row write errors for diversion

### DIFF
--- a/src/elspeth/plugins/infrastructure/clients/dataverse.py
+++ b/src/elspeth/plugins/infrastructure/clients/dataverse.py
@@ -367,6 +367,7 @@ class DataverseClient:
         headers: dict[str, str],
         latency_ms: float,
         *,
+        request_method: Literal["GET", "PATCH"],
         request_url: str | None = None,
         request_headers: dict[str, str] | None = None,
     ) -> DataverseClientError:
@@ -418,20 +419,23 @@ class DataverseClient:
                 request_headers=request_headers,
             )
 
-        # Non-retryable client errors
-        if status_code in (400, 403, 404, 409, 412):
+        # Non-retryable client errors. For writes, these statuses describe the
+        # submitted row and can be handled by the sink's per-row failure policy.
+        if status_code in (400, 403, 404, 409, 412, 422):
             labels = {
                 400: "Bad request",
                 403: "Forbidden",
                 404: "Not found",
                 409: "Conflict (duplicate)",
                 412: "Precondition failed (optimistic concurrency)",
+                422: "Unprocessable entity",
             }
             return DataverseClientError(
                 f"{labels[status_code]} ({status_code})",
                 retryable=False,
                 status_code=status_code,
                 latency_ms=latency_ms,
+                error_category=("row_data_error" if request_method == "PATCH" and status_code != 403 else "protocol_error"),
                 request_url=request_url,
                 request_headers=request_headers,
             )
@@ -459,7 +463,7 @@ class DataverseClient:
 
     def _execute_request(
         self,
-        method: str,
+        method: Literal["GET", "PATCH"],
         url: str,
         *,
         json_body: dict[str, Any] | None = None,
@@ -578,6 +582,7 @@ class DataverseClient:
                 response.status_code,
                 resp_headers,
                 latency_ms,
+                request_method=method,
                 request_url=url,
                 request_headers=fingerprinted,
             )

--- a/tests/unit/plugins/infrastructure/clients/test_dataverse_client.py
+++ b/tests/unit/plugins/infrastructure/clients/test_dataverse_client.py
@@ -491,6 +491,43 @@ class TestErrorClassification:
         assert exc_info.value.retryable is retryable
         assert exc_info.value.status_code == status_code
 
+    @pytest.mark.parametrize("status_code", [400, 404, 409, 412, 422])
+    def test_patch_row_errors_are_classified_as_row_data(
+        self,
+        client: DataverseClient,
+        transport: MockTransport,
+        status_code: int,
+    ) -> None:
+        transport.add_response(httpx.Response(status_code=status_code, text=""))
+
+        with pytest.raises(DataverseClientError) as exc_info:
+            client.upsert(f"{ENV_URL}/api/data/v9.2/accounts(1)", {"name": "invalid"})
+
+        assert exc_info.value.retryable is False
+        assert exc_info.value.error_category == "row_data_error"
+
+    @pytest.mark.parametrize("status_code", [400, 403, 404, 409, 412, 422])
+    def test_get_client_errors_remain_protocol_errors(
+        self,
+        client: DataverseClient,
+        transport: MockTransport,
+        status_code: int,
+    ) -> None:
+        transport.add_response(httpx.Response(status_code=status_code, text=""))
+
+        with pytest.raises(DataverseClientError) as exc_info:
+            client.get_page(f"{ENV_URL}/api/data/v9.2/accounts")
+
+        assert exc_info.value.error_category == "protocol_error"
+
+    def test_patch_forbidden_remains_protocol_error(self, client: DataverseClient, transport: MockTransport) -> None:
+        transport.add_response(httpx.Response(status_code=403, text=""))
+
+        with pytest.raises(DataverseClientError) as exc_info:
+            client.upsert(f"{ENV_URL}/api/data/v9.2/accounts(1)", {"name": "invalid"})
+
+        assert exc_info.value.error_category == "protocol_error"
+
 
 # ---------------------------------------------------------------------------
 # Redirect rejection


### PR DESCRIPTION
### Motivation
- The sink diversion logic only diverts per-row Dataverse failures when `DataverseClientError.error_category == "row_data_error"`, but the production classifier did not emit that category for real PATCH write failures, causing per-row bad data to abort whole batches.

### Description
- Update `_classify_error` to accept the request method and mark non-retryable write responses (PATCH with 400/404/409/412/422) as `error_category="row_data_error"` while preserving `protocol_error` for GET failures and PATCH 403.
- Add `Literal["GET", "PATCH"]` typing to `_execute_request` and propagate the `method` into `_classify_error` so production calls can produce the new category.
- Include HTTP 422 in the client-side divertable status set and label it "Unprocessable entity" for write classification.
- Add unit tests exercising PATCH vs GET classification behavior and the special-case that PATCH 403 remains `protocol_error` in `tests/unit/plugins/infrastructure/clients/test_dataverse_client.py`.

### Testing
- Ran formatting and lint checks with `uv run ruff format --check` and `uv run ruff check` which passed after reformatting two files.
- Verified basic bytecode compilation with `python -m compileall -q` and `git diff --check` which succeeded with no issues reported.
- Attempted to run the targeted pytest collection with `uv run pytest -q tests/unit/plugins/infrastructure/clients/test_dataverse_client.py tests/unit/plugins/sinks/test_dataverse_sink.py tests/unit/engine/test_dataverse_member_effect_diversion.py` but collection failed because `hypothesis` is not installed in the environment and `uv pip install 'hypothesis>=6.152,<7'` could not complete due to the environment's network tunnel restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d4cd5ed083238ab2c8b76b692348)